### PR TITLE
Portability for eopkg

### DIFF
--- a/src/abireport/cmd/scan_packages.go
+++ b/src/abireport/cmd/scan_packages.go
@@ -128,7 +128,7 @@ func locatePackages(searchLocations []string) ([]string, error) {
 	for _, location := range searchLocations {
 		found, err := discoverPackages(location)
 		if err != nil {
-			return nil, fmt.Errorf("Error locating packages: %v\n", err)
+			return nil, fmt.Errorf("error locating packages: %v", err)
 		}
 		discoveredPkgs = append(discoveredPkgs, found...)
 	}


### PR DESCRIPTION
Trivial change which removes requirement for host-provided `uneopkg` binary with a simple pipe with `unzip` and `tar` - considered to be present and at least available on all Linux platforms.

Brownie points: Fixed `make compliant` warning