### PR TITLE
rpm.go: use os.Pipe instead of io.Pipe

### DIFF
--- a/explode/rpm.go
+++ b/explode/rpm.go
@@ -17,7 +17,7 @@
 package explode
 
 import (
-	"io"
+	"os"
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
@@ -49,7 +49,11 @@ func RPM(pkgs []string) (string, error) {
 			"-u",
 		}...)
 		// Pipe rpm into cpio
-		r, w := io.Pipe()
+		r, w , err:= os.Pipe()
+		if err != nil {
+			return "", err
+		}
+
 		defer r.Close()
 		rpm.Stdout = w
 		cpio.Stdin = r
@@ -59,10 +63,8 @@ func RPM(pkgs []string) (string, error) {
 
 		rpm.Start()
 		cpio.Start()
-		go func() {
-			defer w.Close()
-			rpm.Wait()
-		}()
+		defer w.Close()
+		rpm.Wait()
 		if err := cpio.Wait(); err != nil {
 			r.Close()
 			return "", err


### PR DESCRIPTION
There were occasional hangs observed when processing RPMs, as
the piping "rpm2cpio | cpio -imd --quiet -u"
never finished. This was observed mostly with large RPMs.
After switching from io.Pipe to os.Pipe the problems were not
observed.

Signed-off-by: Juro Bystricky <jurobystricky@hotmail.com>