### PR TITLE
manpage: use pandoc instead of ronn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ install: all
 	install -m 00644 man/*.1 $(DESTDIR)/usr/share/man/man1/.; \
 
 gen_docs: man/abireport.1.md
-	@ronn --roff < man/abireport.1.md > man/abireport.1
-	@ronn --html < man/abireport.1.md > man/abireport.1.html
+	pandoc -s -f markdown -t man man/abireport.1.md --output man/abireport.1
+	pandoc -s -f markdown -t html man/abireport.1.md --output man/abireport.1.html
 
 vendor:
 	@go mod vendor

--- a/man/abireport.1.md
+++ b/man/abireport.1.md
@@ -1,6 +1,8 @@
-abireport(1) -- Generate ELF ABI reports
-========================================
+% ABIREPORT(1)
 
+## NAME
+
+`abireport -- Generate ELF ABI reports`
 
 ## SYNOPSIS
 


### PR DESCRIPTION
Creating man pages results in the following error:
   /bin/sh: ronn: command not found

As "ronn" seems to be no longer supported, generate the pages
using "pandoc"

This change necessitated a minor edit in the markdown file.

Signed-off-by: Juro Bystricky <jurobystricky@hotmail.com>