### PR TITLE
walker.go: fix a race condition

### DIFF
--- a/libabi/walker.go
+++ b/libabi/walker.go
@@ -174,6 +174,8 @@ func (a *Report) jobProcessor() {
 			a.jobDone()
 		}()
 	}
+	defer close(a.jobChan)
+	filepath.Walk(a.Root, a.walkTree)
 }
 
 // storeProcessor is responsible for storing into memory
@@ -209,14 +211,9 @@ func (a *Report) storeProcessor() {
 // Walk will attempt to walk the preconfigured tree, and collect a set
 // of "interesting" files along the way.
 func (a *Report) Walk() error {
-	a.wg.Add(3 + a.nJobs)
+	a.wg.Add(2 + a.nJobs)
 	go a.jobProcessor()
 	go a.storeProcessor()
-	go func() {
-		defer a.wg.Done()
-		filepath.Walk(a.Root, a.walkTree)
-		close(a.jobChan)
-	}()
 	a.wg.Wait()
 	return nil
 }


### PR DESCRIPTION
There were occasional hangs detected when processing
empty packages. These were the result of a race condition:

a.JobProcessor and the go function with filepath.Walk were executed
concurrently. For empty packages the go function could terminate
before a.JobProcessor loop dispatched all a.nJobs.

When filepath.Walk terminated, it closed a.JobChan.
If the channel was closed during the jobProcessor dispatch loop,
less than a.nJobs were dispatched. However, jobDone expects
to be called exactly a.nJobs times before closing a.storeChan.

The remedy is to ensure the jobDispatch loop dispatched all
a.nJobs before running the go function with filepath.Walk.

Signed-off-by: Juro Bystricky <jurobystricky@hotmail.com>