### PR TITLE
Do not hardcode version in version.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ gen_docs: man/abireport.1.md
 vendor:
 	@go mod vendor
 
+VARIABLE = github.com/clearlinux/abireport/abi-report/cmd.ABIReportVersion
 all: vendor
-	(cd abi-report && go build --buildmode=pie -mod=vendor -o ../abireport)
+	(cd abi-report && go build --buildmode=pie -mod=vendor -ldflags="-X $(VARIABLE)=$(VERSION)" -o ../abireport)
 
 dist: vendor gen_docs
 	@rm -f abireport-$(VERSION).tar.xz

--- a/abi-report/cmd/version.go
+++ b/abi-report/cmd/version.go
@@ -21,10 +21,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	// ABIReportVersion is the public version of the tool
-	ABIReportVersion = "1.0.7"
-)
+// ABIReportVersion is the public version of the tool. The value is initialized
+// with a linker option to `go build`. See the toplevel Makefile for details.
+var ABIReportVersion = "UNKNOWN"
 
 // versionCmd handles "abireport version"
 var versionCommand = &cobra.Command{


### PR DESCRIPTION
Avoid updating the program version in two different places by
initializing the ABIReportVersion string in the sources via `go build`
linker option.