### PR TITLE
Use /var/tmp instead of /tmp

### DIFF
--- a/explode/dpkg.go
+++ b/explode/dpkg.go
@@ -26,7 +26,7 @@ import (
 // Dpkg will explode all .deb's specified and then return
 // the install/ path inside that exploded tree.
 func Dpkg(pkgs []string) (string, error) {
-	rootDir, err := ioutil.TempDir("", "abireport-dpkg")
+	rootDir, err := ioutil.TempDir("/var/tmp", "abireport-dpkg")
 	if err != nil {
 		return "", err
 	}

--- a/explode/eopkg.go
+++ b/explode/eopkg.go
@@ -27,7 +27,7 @@ import (
 // Eopkg will explode all eopkgs passed to it and return the path to
 // the "root" to walk.
 func Eopkg(pkgs []string) (string, error) {
-	rootDir, err := ioutil.TempDir("", "abireport-eopkg")
+	rootDir, err := ioutil.TempDir("/var/tmp", "abireport-eopkg")
 	if err != nil {
 		return "", err
 	}

--- a/explode/rpm.go
+++ b/explode/rpm.go
@@ -25,7 +25,7 @@ import (
 // RPM will explode all RPMs passed to it and return the path to
 // the "root" to walk.
 func RPM(pkgs []string) (string, error) {
-	rootDir, err := ioutil.TempDir("", "abireport-rpm")
+	rootDir, err := ioutil.TempDir("/var/tmp", "abireport-rpm")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The folder /tmp is typically 50% of installed RAM size.
This may not be enough for large packages. Use /var/tmp
instead. The performance impact is not significant.